### PR TITLE
Fix for manual reset problem

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -89,7 +89,7 @@ class CmdException(Exception):
     pass
 
 class CommandInterface(object):
-    def open(self, aport='/dev/tty.usbserial-000013FAB', abaudrate=500000) :
+    def open(self, aport='/dev/tty.usbserial-000013FAB', abaudrate=500000):
         self.sp = serial.Serial(
             port=aport,
             baudrate=abaudrate,     # baudrate
@@ -100,6 +100,17 @@ class CommandInterface(object):
             rtscts=0,               # disable RTS/CTS flow control
             timeout=0.5             # set a timeout value, None for waiting forever
         )
+
+        # Use the DTR and RTS lines to control !RESET and the bootloader pin.
+        # This can automatically invoke the bootloader without the user
+        # having to toggle any pins.
+        # DTR: connected to the bootloader pin
+        # RTS: connected to !RESET
+        self.sp.setDTR(1)
+        self.sp.setRTS(0)
+        self.sp.setRTS(1)
+        self.sp.setRTS(0)
+        self.sp.setDTR(0)
 
     def close(self):
         self.sp.close()


### PR DESCRIPTION
Having to press a button or remove a jumper to use the bootloader is a major hassle. This commit adds support in the BSL script for a workaround using otherwise unused pins common on FTDI chips: DTR and RTS. These are both outputs, and since they are not being used for flow control, DTR can be used to toggle the bootloader pin and RTS can be used to toggle the !RESET line in order to enable the bootloader.

To have the BSL script automatically invoke the bootloader, pass the -i flag when calling the script.

I was able to get this working with FTDI boards I have for programming the MSP430F1611 using BSL. I don't think this can be used with the SmartRF06 board because it doesn't seem to export a DTR pin (although I would love to be wrong).

I'm not sure if this is the best way to implement this but I thought I would at least get it in code because I think it is absolutely critical to making the bootloader a viable option for programming the CC2538. Having to remove a jumper or push a button each time is only just a bit better than the pain of uniflash and smartrf programmer 2.

Here is a salae shot of what toggling the pins does. The DTR pin stays low and !RESET goes low, entering the bootloader. Then both pins are released.
![cc2538_auto_invoke](https://f.cloud.github.com/assets/1467890/2353261/00652160-a59d-11e3-9903-381ed2c896e2.PNG)
