### PR TITLE
Return an error code if exiting due to an error 

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -689,4 +689,4 @@ if __name__ == "__main__":
         cmd.cmdReset()
 
     except Exception, err:
-        print('ERROR: %s' % str(err))
+        exit('ERROR: %s' % str(err))


### PR DESCRIPTION
...so that a higher-level Makefile or shell script is aware of the failure.
