### PR TITLE
Support for Python3

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -41,7 +41,6 @@ from __future__ import print_function
 from subprocess import Popen, PIPE
 
 import sys, getopt
-import serial
 import glob
 import time
 import tempfile
@@ -65,6 +64,21 @@ QUIET = 5
 
 # Check which version of Python is running
 PY3 = sys.version_info >= (3,0)
+
+try:
+    import serial
+except ImportError:
+    print('{} requires the Python serial library'.format(sys.argv[0]))
+    print('Please install it with one of the following:')
+    print('')
+    if PY3:
+        print('   Ubuntu:  sudo apt-get install python3-serial')
+        print('   Mac:     sudo port install py34-serial')
+    else:
+        print('   Ubuntu:  sudo apt-get install python-serial')
+        print('   Mac:     sudo port install py-serial')
+    sys.exit(1)
+
 
 def mdebug(level, message, attr='\n'):
     if QUIET >= level:


### PR DESCRIPTION
The major changes:
- Wrapper functions for serial write and read. Python2 uses strings and
  Python3 uses bytes. The wrapper function handles the difference.
- Only use `ord()` in Python2. Bytes don't need this.
- General version checking when the bytes vs str distinction matters.
- Checking around other function name changes.

Using `_read()` and `_write()` wrapper functions allows both Python2 and Python3 serial to return values that can be understood by the rest of the code without need for `ord()` or `if PY3:`.
