### PR TITLE
Add delay after reset when entering bootloader

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -120,6 +120,9 @@ class CommandInterface(object):
         self.sp.setRTS(0)
         self.sp.setRTS(1)
         self.sp.setRTS(0)
+        time.sleep(0.002)  # Make sure the pin is still asserted when the cc2538
+                           # comes out of reset. This fixes an issue where there
+                           # wasn't enough delay here on Mac.
         self.sp.setDTR(0)
 
     def close(self):


### PR DESCRIPTION
On certain Mac platforms, toggling UART pins to enter the bootloader
were happening too fast, causing the CC2538 to not detect that it should
enter the bootloader and ending with the script not working. Adding this
delay takes care of that problem while not affecting the bsl script on
Linux.