### PR TITLE
Two small Py3k fixes.

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -181,6 +181,8 @@ class CommandInterface(object):
                 self.sp.write(bytes([data]))
             elif type(data) == bytes or type(data) == bytearray:
                 self.sp.write(data)
+            else:
+                raise CmdException("Internal Error. Bad data type: {}".format(type(data)))
         else:
             if type(data) == int:
                 self.sp.write(chr(data))
@@ -195,13 +197,13 @@ class CommandInterface(object):
             return [ord(x) for x in got]
 
     def sendAck(self):
-        self._write(chr(0x00))
+        self._write(0x00)
         self._write(0xCC)
         return
 
     def sendNAck(self):
-        self._write(chr(0x00))
-        self._write(chr(0x33))
+        self._write(0x00)
+        self._write(0x33)
         return
 
 


### PR DESCRIPTION
* Remove pre-emptive calls to `chr`, let `_write` handle this
* Add a check for the error case to catch this more easily in the future