### PR TITLE
Add Silicon Labs USB Port Name in Mac OS X

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -669,7 +669,7 @@ if __name__ == "__main__":
             ports = []
 
             # Get a list of all USB-like names in /dev
-            for name in ['tty.usbserial', 'ttyUSB', 'tty.usbmodem']:
+            for name in ['tty.usbserial', 'ttyUSB', 'tty.usbmodem', 'tty.SLAB_USBtoUART']:
                 ports.extend(glob.glob('/dev/%s*' % name))
 
             ports = sorted(ports)


### PR DESCRIPTION
We have a cc2538-based mote with a Silicon Labs CP2104 USB-to-UART bridge chip. You can find the datasheet in here: https://www.silabs.com/Support%20Documents/TechnicalDocs/cp2104.pdf

In Mac OS X, this chip creates the next type of /dev/tty ports:
```
/dev/tty.SLAB_USBtoUART		
/dev/tty.SLAB_USBtoUART6
```

So, this pull adds SLAB_USBtoUART to the list of possible port names. 


