### PR TITLE
Fixed DTR/RTS bootloader

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -111,6 +111,7 @@ class CommandInterface(object):
             timeout=0.5             # set a timeout value, None for waiting forever
         )
 
+    def invoke_bootloader(self):
         # Use the DTR and RTS lines to control !RESET and the bootloader pin.
         # This can automatically invoke the bootloader without the user
         # having to toggle any pins.
@@ -682,6 +683,7 @@ if __name__ == "__main__":
 
         cmd = CommandInterface()
         cmd.open(conf['port'], conf['baud'])
+        cmd.invoke_bootloader()
         mdebug(5, "Opening port %(port)s, baud %(baud)d" % {'port':conf['port'],
                                                       'baud':conf['baud']})
         if conf['write'] or conf['verify']:


### PR DESCRIPTION
It was firing twice, when connecting and reconnecting after clock switching, resetting again the device.With this fix it works fine in mac, but in Linux apparently there is a bug in the drivers for the usb-to-serial chip that we use (CP2104), causing a reset on the RST line whenever a serial connection is opened.