### PR TITLE
Add CC26xx support

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -692,6 +692,15 @@ if __name__ == "__main__":
         if not cmd.sendSynch():
             raise CmdException("Can't connect to target. Ensure boot loader is started. (no answer on synch sequence)")
 
+        chip_id = cmd.cmdGetChipId()
+        chip_id_str = CHIP_ID_STRS.get(chip_id, None)
+
+        if chip_id_str is None:
+            mdebug(0, 'Warning: unrecognized chip ID 0x%x' % chip_id)
+            conf['force_speed'] = 1
+        else:
+            mdebug(5, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
+
         if conf['force_speed'] != 1:
             if cmd.cmdSetXOsc(): #switch to external clock source
                 cmd.close()
@@ -706,14 +715,6 @@ if __name__ == "__main__":
 
         # if (cmd.cmdPing() != 1):
         #     raise CmdException("Can't connect to target. Ensure boot loader is started. (no answer on ping command)")
-
-        chip_id = cmd.cmdGetChipId()
-        chip_id_str = CHIP_ID_STRS.get(chip_id, None)
-
-        if chip_id_str is None:
-            mdebug(0, 'Warning: unrecognized chip ID 0x%x' % chip_id)
-        else:
-            mdebug(5, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
 
         if conf['erase']:
             # we only do full erase for now (CC2538)

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -590,7 +590,7 @@ if __name__ == "__main__":
             'port': 'auto',
             'baud': 500000,
             'force_speed' : 0,
-            'address': 0x00200000,
+            'address': 0x00000000,
             'erase': 0,
             'write': 0,
             'verify': 0,

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -370,13 +370,14 @@ class CommandInterface(object):
 
     def cmdCRC32(self, addr, size):
         cmd=0x27
-        lng=11
+        lng=15
 
         self._write(lng) # send length
         self._write(self._calc_checks(cmd,addr,size)) # send checksum
         self._write(cmd) # send cmd
         self._write(self._encode_addr(addr)) # send addr
         self._write(self._encode_addr(size)) # send size
+        self._write(self._encode_addr(0x00000000)) # send number of reads
 
         mdebug(10, "*** CRC32 command(0x27)")
         if self._wait_for_ack("Get CRC32 (0x27)",1):

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -355,17 +355,15 @@ class CommandInterface(object):
         return 1
 
     def cmdEraseMemory(self, addr, size):
-        cmd=0x26
-        lng=11
+        cmd=0x2C
+        lng=3
 
         self._write(lng) # send length
-        self._write(self._calc_checks(cmd,addr,size)) # send checksum
+        self._write(cmd) # send checksum
         self._write(cmd) # send cmd
-        self._write(self._encode_addr(addr)) # send addr
-        self._write(self._encode_addr(size)) # send size
 
-        mdebug(10, "*** Erase command(0x26)")
-        if self._wait_for_ack("Erase memory (0x26)",10):
+        mdebug(10, "*** Bank Erase command(0x2C)")
+        if self._wait_for_ack("Bank Erase (0x2C)",10):
             return self.checkLastCmd()
 
     def cmdCRC32(self, addr, size):


### PR DESCRIPTION
This adds CC26xx support in a separate branch `feature/CC26xx_support` until the two can be merged together. This branch will not support CC2538 though.

This branch is little behind master, hence the commits appear in the history here. I _think_ that if you manually move the branch forward to mirror master, the respective commits will disappear from the history here. Happy to rebase if they don't