### PR TITLE
Don't fail when `COMMAND_GET_STATUS` signals an error

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -274,11 +274,11 @@ class CommandInterface(object):
             mdebug(10, "Command Successful")
             return 1
         else:
-            stat_str = RETURN_CMD_STRS.get(stat, None)
+            stat_str = RETURN_CMD_STRS.get(stat[0], None)
             if stat_str is None:
-                mdebug(0, 'Warning: unrecognized status returned 0x%x' % stat)
+                mdebug(0, 'Warning: unrecognized status returned 0x%x' % stat[0])
             else:
-                mdebug(0, "Target returned: 0x%x, %s" % (stat, stat_str))
+                mdebug(0, "Target returned: 0x%x, %s" % (stat[0], stat_str))
             return 0
 
 


### PR DESCRIPTION
If `COMMAND_GET_STATUS` returns anything other than `COMMAND_RET_SUCCESS` (0x40), the script will fail with `ERROR: unhashable type: 'list'`. This is a `TypeError`. This commit fixes this bug.

Reproducing is easy: Simply send a command with a junk address.

Here is an example of broken execution:

```
*** Send Data (0x24)
*** GetStatus command (0x23)
*** received 3 bytes
Traceback (most recent call last):
  File "cc2538-bsl.py", line 847, in <module>
    if cmd.writeMemory(device.addr_ieee_address_secondary, ieee_addr_bytes):
  File "cc2538-bsl.py", line 531, in writeMemory
    return self.cmdSendData(data[offs:offs+lng]) # send last data packet
  File "cc2538-bsl.py", line 451, in cmdSendData
    return self.checkLastCmd()
  File "cc2538-bsl.py", line 274, in checkLastCmd
    stat_str = RETURN_CMD_STRS.get(stat, None)
TypeError: unhashable type: 'list'
ERROR: unhashable type: 'list'
```