### PR TITLE
Add CC13xx and CC26xx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-TI CC2538 Serial Boot Loader
-============================
+TI CC2538/CC13xx/CC26xx Serial Boot Loader
+==========================================
 
-This folder contains a python script that communicates with the boot loader of the Texas Instruments CC2538 SoC (System on Chip).
-It can be used to erase, program, verify and read the flash of the CC2538 with a simple USB to serial converter.
+This folder contains a python script that communicates with the boot loader of the Texas Instruments CC2538, CC26xx and CC13xx SoCs (System on Chip).
+It can be used to erase, program, verify and read the flash of those SoCs with a simple USB to serial converter.
 
 ###Requirements
 
 To run this script you need a Python interpreter, Linux and Mac users should be fine, Windows users have a look here: [Python Download][python].
 
-To communicate with the uart port of the CC2538 SoC you need a usb to serial converter:   
-* If you use the SmartRF06 board (CC2538DK) you can use the on-board ftdi chip. Make sure the "Enable UART" jumper is set on the board. You can have a look [here][contiki cc2538dk] for more info on drivers for this chip on different operating systems.
+To communicate with the uart port of the SoC you need a usb to serial converter:
+* If you use the SmartRF06 board with an Evaluation Module (EM) mounted on it you can use the on-board ftdi chip. Make sure the "Enable UART" jumper is set on the board. You can have a look [here][contiki cc2538dk] for more info on drivers for this chip on different operating systems.
 * If you use a different platform, there are many cheap USB to UART converters available, but make sure you use one with 3.3v voltage levels.
 
-###Boot Loader Backdoor
+###CC2538 Boot Loader Backdoor
 
 Once you connected the SoC you need to make sure the serial boot loader is enabled. A chip without a valid image (program), as it comes from the factory, will automatically start the boot loader. After you upload an image to the chip, the "Image Valid" bits are set to 0 to indicate that a valid image is present in flash. On the next reset the boot loader won't be started and the image is immediately executed.   
 To make sure you don't get "locked out", i.e. not being able to communicate over serial with the boot loader in the SoC anymore, you need to enable the boot loader backdoor in your image (the script currently only checks this on firmware for the 512K model). When the boot loader backdoor is enabled the boot loader will be started when the chip is reset and a specific pin of the SoC is pulled high or low (configurable).   
@@ -35,12 +35,10 @@ You can find more info on the different options by executing `python cc2538-bsl.
 
 If you found a bug or improved some part of the code, please submit an issue or pull request.
 
-###CC26xx Support
-Branch `feature/CC26xx_support` of this script supports programming TI's CC26xx family of chips, but bear in mind that this branch will not support the CC2538. Ultimately, support for both chips will be merged into master, but for the time being you will have to switch around depending what you wish to program.
+###CC26xx and CC13xx Support
+The script has been tested with SmartRF06EB + CC2650 EM. The physical wiring on the CC2650 Sensortag does not meet the ROM bootloader's requirements in terms of serial interface configuration. For that reason, interacting with the Sensortag via this script is (and will remain) impossible.
 
-The script has been tested with SmartRF06EB + CC2650 EM. The physical wiring on the CC2650 Sensortag does not meet the ROM bootloader's requirements in terms of serial interface configuration. For that reason, interacting with the Sensortag via this script is impossible.
-
-The ROM bootloader is configured through the `BL_CONFIG` 'register' in CCFG. `BOOTLOADER_ENABLE` should be set to `0xC5` to enable the bootloader in the first place.
+For the CC13xx and CC26xx families, the ROM bootloader is configured through the `BL_CONFIG` 'register' in CCFG. `BOOTLOADER_ENABLE` should be set to `0xC5` to enable the bootloader in the first place.
 
 This is enough if the chip has not been programmed with a valid image. If a valid image is present, then the remaining fields of `BL_CONFIG` and the `ERASE_CONF` register must also be configured correctly:
 
@@ -49,7 +47,16 @@ This is enough if the chip has not been programmed with a valid image. If a vali
 * Enable 'failure analysis' by setting `BL_ENABLE` to `0xC5`
 * Make sure the `BANK_ERASE` command is enabled: The `BANK_ERASE_DIS_N` bit in the `ERASE_CONF` register in CCFG must be set. `BANK_ERASE` is enabled by default.
 
+If you are using CC13xx/CC26xxware, the relevant settings are under `startup_files/ccfg.c`. This is the case if you are using Contiki.
+
 Similar to the CC2538, the bootloader will be activated if, at the time of reset, failure analysis is enabled and the selected DIO is found to be at the active level.
+
+As an example, to bind the bootloader backdoor to KEY_SELECT on the SmartRF06EB, you need to set the following:
+
+* `BOOTLOADER_ENABLE = 0xC5` (Bootloader enable. `SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE` in CC13xx/CC26xxware)
+* `BL_LEVEL = 0x00` (Active low. `SET_CCFG_BL_CONFIG_BL_LEVEL` in CC13xx/CC26xxware)
+* `BL_PIN_NUMBER = 0x0B` (DIO 11. `SET_CCFG_BL_CONFIG_BL_PIN_NUMBER` in CC13xx/CC26xxware)
+* `BL_ENABLE = 0xC5` (Enable "failure analysis". `SET_CCFG_BL_CONFIG_BL_ENABLE` in CC13xx/CC26xxware)
 
 These settings are very useful for development, but enabling failure analysis in a deployed firmware may allow a malicious user to read out the contents of your device's flash or to erase it. Do not enable this in a deployment unless you understand the security implications.
 

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -392,6 +392,23 @@ class CommandInterface(object):
             if self.checkLastCmd():
                 return self._decode_addr(crc[3],crc[2],crc[1],crc[0])
 
+    def cmdCRC32CC26xx(self, addr, size):
+        cmd = 0x27
+        lng = 15
+
+        self._write(lng) # send length
+        self._write(self._calc_checks(cmd, addr, size)) # send checksum
+        self._write(cmd) # send cmd
+        self._write(self._encode_addr(addr)) # send addr
+        self._write(self._encode_addr(size)) # send size
+        self._write(self._encode_addr(0x00000000)) # send number of reads
+
+        mdebug(10, "*** CRC32 command(0x27)")
+        if self._wait_for_ack("Get CRC32 (0x27)", 1):
+            crc=self.receivePacket()
+            if self.checkLastCmd():
+                return self._decode_addr(crc[3], crc[2], crc[1], crc[0])
+
     def cmdDownload(self, addr, size):
         cmd=0x21
         lng=11

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -311,6 +311,7 @@ class CommandInterface(object):
             version = self.receivePacket() # 4 byte answ, the 2 LSB hold chip ID
             if self.checkLastCmd():
                 assert len(version) == 4, "Unreasonable chip id: %s" % repr(version)
+                mdebug(5, "    Version 0x%02X%02X%02X%02X" % tuple(version))
                 chip_id = (version[2] << 8) | version[3]
                 return chip_id
             else:
@@ -809,9 +810,11 @@ if __name__ == "__main__":
         chip_id_str = CHIP_ID_STRS.get(chip_id, None)
 
         if chip_id_str is None:
-            mdebug(0, 'Warning: unrecognized chip ID 0x%x' % chip_id)
+            mdebug(0, 'Warning: unrecognized chip ID. Selecting CC13xx/CC26xx')
+            device = CC26xx(cmd)
         else:
             mdebug(5, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
+            device = CC2538(cmd)
 
         if conf['erase']:
             # we only do full erase for now (CC2538)

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -679,7 +679,7 @@ if __name__ == "__main__":
             'port': 'auto',
             'baud': 500000,
             'force_speed' : 0,
-            'address': 0x00200000,
+            'address': None,
             'force': 0,
             'erase': 0,
             'write': 0,
@@ -815,6 +815,10 @@ if __name__ == "__main__":
         else:
             mdebug(5, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
             device = CC2538(cmd)
+
+        # Choose a good default address unless the user specified -a
+        if conf['address'] is None:
+            conf['address'] = device.flash_start_addr
 
 
         if conf['erase']:

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -94,12 +94,6 @@ COMMAND_RET_INVALID_CMD = 0x42
 COMMAND_RET_INVALID_ADR = 0x43
 COMMAND_RET_FLASH_FAIL = 0x44
 
-FLASH_CCA_BOOTLDR_ADDRESS = 0x0027ffd4
-if PY3:
-    FLASH_CCA_BOOTLDR_CLOSED = struct.pack('<L', 0xefffffff)
-else:
-    FLASH_CCA_BOOTLDR_CLOSED = [ord(b) for b in struct.pack('<L', 0xefffffff)]
-
 class CmdException(Exception):
     pass
 
@@ -879,14 +873,7 @@ if __name__ == "__main__":
             mdebug(5, "    Read done                                ")
 
         if conf['disable-bootloader']:
-            if not ( conf['force'] or query_yes_no("Disabling the bootloader will prevent you from "\
-                                "using this script until you re-enable the bootloader "\
-                                "using JTAG. Do you want to continue?","no") ):
-                raise Exception('Aborted by user.')
-            if cmd.writeMemory(FLASH_CCA_BOOTLDR_ADDRESS, FLASH_CCA_BOOTLDR_CLOSED):
-                mdebug(5, "    Set bootloader closed done                      ")
-            else:
-                raise CmdException("Set bootloader closed failed             ")
+            device.disable_bootloader()
 
         cmd.cmdReset()
 

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -791,18 +791,6 @@ if __name__ == "__main__":
         if not cmd.sendSynch():
             raise CmdException("Can't connect to target. Ensure boot loader is started. (no answer on synch sequence)")
 
-        if conf['force_speed'] != 1:
-            if cmd.cmdSetXOsc(): #switch to external clock source
-                cmd.close()
-                conf['baud']=1000000
-                cmd.open(conf['port'], conf['baud'])
-                mdebug(6, "Opening port %(port)s, baud %(baud)d" % {'port':conf['port'],'baud':conf['baud']})
-                mdebug(6, "Reconnecting to target at higher speed...")
-                if (cmd.sendSynch()!=1):
-                    raise CmdException("Can't connect to target after clock source switch. (Check external crystal)")
-            else:
-                raise CmdException("Can't switch target to external clock source. (Try forcing speed)")
-
         # if (cmd.cmdPing() != 1):
         #     raise CmdException("Can't connect to target. Ensure boot loader is started. (no answer on ping command)")
 
@@ -820,6 +808,17 @@ if __name__ == "__main__":
         if conf['address'] is None:
             conf['address'] = device.flash_start_addr
 
+        if conf['force_speed'] != 1 and device.has_cmd_set_xosc:
+            if cmd.cmdSetXOsc(): #switch to external clock source
+                cmd.close()
+                conf['baud'] = 1000000
+                cmd.open(conf['port'], conf['baud'])
+                mdebug(6, "Opening port %(port)s, baud %(baud)d" % {'port':conf['port'], 'baud':conf['baud']})
+                mdebug(6, "Reconnecting to target at higher speed...")
+                if (cmd.sendSynch() != 1):
+                    raise CmdException("Can't connect to target after clock source switch. (Check external crystal)")
+            else:
+                raise CmdException("Can't switch target to external clock source. (Try forcing speed)")
 
         if conf['erase']:
             # we only do full erase for now

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -816,13 +816,10 @@ if __name__ == "__main__":
             mdebug(5, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
             device = CC2538(cmd)
 
-        if conf['erase']:
-            # we only do full erase for now (CC2538)
-            address = 0x00200000 #flash start addr for cc2538
-            size = 0x80000 #total flash size cc2538
-            mdebug(5, "Erasing %s bytes starting at address 0x%x" % (size, address))
 
-            if cmd.cmdEraseMemory(address, size):
+        if conf['erase']:
+            # we only do full erase for now
+            if device.erase():
                 mdebug(5, "    Erase done")
             else:
                 raise CmdException("Erase failed")

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -476,7 +476,7 @@ class CommandInterface(object):
                     "Do you want to continue?","no") ):
                     raise Exception('Aborted by user.')
 
-        mdebug(5, "Writing %(lng)d bytes starting at address 0x%(addr)X" %
+        mdebug(5, "Writing %(lng)d bytes starting at address 0x%(addr)08X" %
                { 'lng': lng, 'addr': addr})
 
         offs = 0
@@ -487,7 +487,7 @@ class CommandInterface(object):
                 if addr_set != 1:
                     self.cmdDownload(addr,lng) #set starting address if not set
                     addr_set = 1
-                mdebug(5, " Write %(len)d bytes at 0x%(addr)X" % {'addr': addr, 'len': trsf_size}, '\r')
+                mdebug(5, " Write %(len)d bytes at 0x%(addr)08X" % {'addr': addr, 'len': trsf_size}, '\r')
                 sys.stdout.flush()
 
                 self.cmdSendData(data[offs:offs+trsf_size]) # send next data packet
@@ -498,7 +498,7 @@ class CommandInterface(object):
             addr = addr + trsf_size
             lng = lng - trsf_size
 
-        mdebug(5, "Write %(len)d bytes at 0x%(addr)X" % {'addr': addr, 'len': lng}, '\r')
+        mdebug(5, "Write %(len)d bytes at 0x%(addr)08X" % {'addr': addr, 'len': lng})
         self.cmdDownload(addr,lng)
         return self.cmdSendData(data[offs:offs+lng]) # send last data packet
 

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -838,7 +838,7 @@ if __name__ == "__main__":
             mdebug(5,"Verifying by comparing CRC32 calculations.")
 
             crc_local = (binascii.crc32(bytearray(data))& 0xffffffff)
-            crc_target = cmd.cmdCRC32(conf['address'],len(data)) #CRC of target will change according to length input file
+            crc_target = device.crc(conf['address'], len(data)) #CRC of target will change according to length input file
 
             if crc_local == crc_target:
                 mdebug(5, "    Verified (match: 0x%08x)" % crc_local)

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -51,7 +51,7 @@ import binascii
 import traceback
 
 #version
-VERSION_STRING = "1.1"
+VERSION_STRING = "1.2"
 
 # Verbose level
 QUIET = 5

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -376,6 +376,18 @@ class CommandInterface(object):
         if self._wait_for_ack("Erase memory (0x26)",10):
             return self.checkLastCmd()
 
+    def cmdBankErase(self):
+        cmd = 0x2C
+        lng = 3
+
+        self._write(lng) # send length
+        self._write(cmd) # send checksum
+        self._write(cmd) # send cmd
+
+        mdebug(10, "*** Bank Erase command(0x2C)")
+        if self._wait_for_ack("Bank Erase (0x2C)",10):
+            return self.checkLastCmd()
+
     def cmdCRC32(self, addr, size):
         cmd=0x27
         lng=11

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -94,8 +94,6 @@ COMMAND_RET_INVALID_CMD = 0x42
 COMMAND_RET_INVALID_ADR = 0x43
 COMMAND_RET_FLASH_FAIL = 0x44
 
-ADDR_IEEE_ADDRESS_SECONDARY = 0x0027ffcc
-
 FLASH_CCA_BOOTLDR_ADDRESS = 0x0027ffd4
 if PY3:
     FLASH_CCA_BOOTLDR_CLOSED = struct.pack('<L', 0xefffffff)
@@ -860,7 +858,7 @@ if __name__ == "__main__":
                 mdebug(5, "Setting IEEE address to %s" % (':'.join(['%02x' % ord(b) for b in struct.pack('>Q', ieee_addr)])))
                 ieee_addr_bytes = [ord(b) for b in struct.pack('<Q', ieee_addr)]
 
-            if cmd.writeMemory(ADDR_IEEE_ADDRESS_SECONDARY, ieee_addr_bytes):
+            if cmd.writeMemory(device.addr_ieee_address_secondary, ieee_addr_bytes):
                 mdebug(5, "    Set address done                                ")
             else:
                 raise CmdException("Set address failed                       ")


### PR DESCRIPTION
This pull adds support for the CC13xx and CC26xx.

For the CC13xx, we currently only support the 128KB flash variant. In terms of bootloader functionality, protocol etc, the two devices are identical.

More specifically, this pull:

* Introduces chip auto-detection: The CC13xx/CC26xx TRM is quite obscure in terms of the return values of `COMMAND_GET_CHIP_ID`. Therefore, unless the return value matches good old CC2538's  CHIP ID, we assume CC13xx/CC26xx. Seeing some sort of Chip ID in response to said command means we are talking to a device that supports the bootloader's protocol, so not failing for unknown chip IDs makes sense.
* Implements a couple of new commands for the CC13xx/CC26xx (e.g. `COMMAND_BANK_ERASE`)
* Introduces a chip abstraction / class hierarchy.

In terms of this abstraction, class `CC2538` and `CC26xx` implement chip-specific operations, as is the case for the flash erase and verify operations. They also define chip-specific parameters, e.g. the default flash start address, location of the secondary IEEE address and whether `COMMAND_SET_XOSC` is supported. 

Both classes inherit from the generic class `Chip`. Chip auto-detection (above) automatically instantiates an object of the correct class.

This allows us to abstract script operations by doing e.g. `device.erase()` or `device.crc()`. Ultimately all script operations will go through these classes, common ones implemented as methods of `Chip` (e.g. `device.write()`). This will make the script easier to extend with support for future chips. For now, we implement chip-specific operations only. This is basically a partial first stab of some of the things discussed in #25.

In less important news: The CC13xx/CC26xx do not support `COMMAND_SET_XOSC`, so we cannot speed-up the UART the same way we do for the CC2538. For this reason, attempting to do so now happens after chip auto-detection.

Successful execution with SmartRF06EB + CC2650EM:

```
$ python cc2538-bsl.py -p /dev/tty.usbserial-00001014B -D -e -w -v -i 00:12:4b:aa:bb:cc:dd:ee cc2650.bin 
Opening port /dev/tty.usbserial-00001014B, baud 500000
Reading data from cc2650.bin
Connecting to target...
    Version 0x8002F000
Warning: unrecognized chip ID. Selecting CC13xx/CC26xx
Erasing all main bank flash sectors
    Erase done
Writing 131072 bytes starting at address 0x00000000
Write 128 bytes at 0x0001FF800
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x3c56d896)
Setting IEEE address to 00:12:4b:aa:bb:cc:dd:ee
Writing 8 bytes starting at address 0x0001FFC8
Write 8 bytes at 0x0001FFC8
    Set address done                                
Disabling the bootloader will prevent you from using this script until you re-enable the bootloader using JTAG. Do you want to continue? [y/N] y
Writing 4 bytes starting at address 0x0001FFD8
Write 4 bytes at 0x0001FFD8
ERROR: No response from target on status request. (Did you disable the bootloader?)
```

Closes #25 