### PR TITLE
Add support for programming from intel hex files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ To communicate with the uart port of the SoC you need a usb to serial converter:
 * If you use the SmartRF06 board with an Evaluation Module (EM) mounted on it you can use the on-board ftdi chip. Make sure the "Enable UART" jumper is set on the board. You can have a look [here][contiki cc2538dk] for more info on drivers for this chip on different operating systems.
 * If you use a different platform, there are many cheap USB to UART converters available, but make sure you use one with 3.3v voltage levels.
 
+###Dependencies
+
+If you want to be able to program your device from an Intel Hex file, you will need to install the IntelHex package: https://pypi.python.org/pypi/IntelHex (e.g. by running `pip install intelhex`).
+
+The script will try to auto-detect whether your firmware is a raw binary or an Intel Hex by using python-magic:
+(https://pypi.python.org/pypi/python-magic). You can install it by running `pip install python-magic`. Please bear in mind that installation of python-magic may have additional dependencies, depending on your OS: (https://github.com/ahupp/python-magic#dependencies).
+
+If python-magic is _not_ installed, the script will try to auto-detect the firmware type by looking at the filename extension, but this is sub-optimal. If the extension is `.hex`, `.ihx` or `.ihex`, the script will assume that the firmware is an Intel Hex file. In all other cases, the firmware will be treated as raw binary.
+
 ###CC2538 Boot Loader Backdoor
 
 Once you connected the SoC you need to make sure the serial boot loader is enabled. A chip without a valid image (program), as it comes from the factory, will automatically start the boot loader. After you upload an image to the chip, the "Image Valid" bits are set to 0 to indicate that a valid image is present in flash. On the next reset the boot loader won't be started and the image is immediately executed.   

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -50,6 +50,18 @@ import struct
 import binascii
 import traceback
 
+try:
+    import magic
+    have_magic = True
+except ImportError:
+    have_magic = False
+
+try:
+    from intelhex import IntelHex
+    have_hex_support = True
+except ImportError:
+    have_hex_support = False
+
 #version
 VERSION_STRING = "1.2"
 
@@ -96,6 +108,85 @@ COMMAND_RET_FLASH_FAIL = 0x44
 
 class CmdException(Exception):
     pass
+
+class FirmwareFile(object):
+    HEX_FILE_EXTENSIONS = ('hex', 'ihx', 'ihex')
+
+    def __init__(self, path):
+        """
+        Read a firmware file and store its data ready for device programming.
+
+        This class will try to guess the file type if python-magic is available.
+
+        If python-magic indicates a plain text file, and if IntelHex is
+        available, then the file will be treated as one of Intel HEX format.
+
+        In all other cases, the file will be treated as a raw binary file.
+
+        In both cases, the file's contents are stored in bytes for subsequent
+        usage to program a device or to perform a crc check.
+
+        Parameters:
+            path -- A str with the path to the firmware file.
+
+        Attributes:
+            bytes: A bytearray with firmware contents ready to send to the device
+        """
+        self._crc32 = None
+        firmware_is_hex = False
+
+        if have_magic:
+            file_type = bytearray(magic.from_file(path, True))
+
+            #from_file() returns bytes with PY3, str with PY2. This comparison
+            #will be True in both cases"""
+            if file_type == b'text/plain':
+                firmware_is_hex = True
+                mdebug(5, "Firmware file: Intel Hex")
+            elif file_type == b'application/octet-stream':
+                mdebug(5, "Firmware file: Raw Binary")
+            else:
+                error_str = "Could not determine firmware type. Magic " \
+                            "indicates '%s'" % (file_type)
+                raise CmdException(error_str)
+        else:
+            if os.path.splitext(path)[1][1:] in self.HEX_FILE_EXTENSIONS:
+                firmware_is_hex = True
+                mdebug(5, "Your firmware looks like an Intel Hex file")
+            else:
+                mdebug(5, "Cannot auto-detect firmware filetype: Assuming .bin")
+
+            mdebug(10, "For more solid firmware type auto-detection, install "
+                       "python-magic.")
+            mdebug(10, "Please see the readme for more details.")
+
+        if firmware_is_hex:
+            if have_hex_support:
+                self.bytes = bytearray(IntelHex(path).tobinarray())
+                return
+            else:
+                error_str = "Firmware is Intel Hex, but the IntelHex library " \
+                            "could not be imported.\n" \
+                            "Install IntelHex in site-packages or program " \
+                            "your device with a raw binary (.bin) file.\n" \
+                            "Please see the readme for more details."
+                raise CmdException(error_str)
+
+        with open(path, 'rb') as f:
+            self.bytes = bytearray(f.read())
+
+    def crc32(self):
+        """
+        Return the crc32 checksum of the firmware image
+
+        Return:
+            The firmware's CRC32, ready for comparison with the CRC
+            returned by the ROM bootloader's COMMAND_CRC32
+        """
+        if self._crc32 is None:
+            self._crc32 = binascii.crc32(bytearray(self.bytes)) & 0xffffffff
+
+        return self._crc32
 
 class CommandInterface(object):
     def open(self, aport='/dev/tty.usbserial-000013FAB', abaudrate=500000):

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -591,10 +591,7 @@ class CommandInterface(object):
     def writeMemory(self, addr, data):
         lng = len(data)
         trsf_size = 248 # amount of data bytes transferred per packet (theory: max 252 + 3)
-        if PY3:
-            empty_packet = b'\xff'*trsf_size # empty packet (filled with 0xFF)
-        else:
-            empty_packet = [255]*trsf_size # empty packet (filled with 0xFF)
+        empty_packet = bytearray((0xFF,) * trsf_size)
 
         # Boot loader enable check
         # TODO: implement check for all chip sizes & take into account partial firmware uploads


### PR DESCRIPTION
This will need rebased, but feel free to have a look at the feature. It is implemented in the last 4 commits of this pull.

Requires `IntelHex` and `python-magic` in site-packages.

With those packages available, we auto-detect the firmware type.

If those packages are not available, support for .hex will be disabled gracefully and the script will still work the way it does ~~not~~ for bin files.