### PR TITLE
Don't fail if the device sends leftover bytes before ACK/NACK

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -205,11 +205,7 @@ class CommandInterface(object):
                 return self._write(data[written:], is_retry=True)
 
     def _read(self, length):
-        got = self.sp.read(length)
-        if PY3:
-            return got
-        else:
-            return [ord(x) for x in got]
+        return bytearray(self.sp.read(length))
 
     def sendAck(self):
         self._write(0x00)


### PR DESCRIPTION
As discussed in #13, if the device is running a firmware that prints characters over the UART, those characters will on occasion get buffered. When the bootloader receives the synch sequence (`0x55, 0x55`), those buffered bytes will appear on the host's serial line before the ACK/NACK sequence.

The current version of the script reads 2 bytes when expecting ACK/NACK, and it will therefore fail in the conditions discussed above (since the first 2 bytes received are buffered leftovers instead of an ACK/NACK).

This pull proposes changing `_wait_for_ack` to read byte-by-byte until it encounters ACK/NACK or until it times out.

To reproduce, program the device with a firmware that prints stuff: Contiki's startup sequence will do. Reset the device manually a couple of times and then perform the key press sequence to enter the bootloader. Run the script and it will likely fail under the above conditions. Then repeat the above with this patch in place and run with `-V`. Observe the bold line below:

<pre>
Connecting to target...
*** sending synch sequence
<b>Got 510 additional bytes before ACK/NACK</b>
</pre>

whereas normally you should see:

<pre>
Connecting to target...
*** sending synch sequence
<b>Got 0 additional bytes before ACK/NACK</b>
</pre>

A known downside of this approach is that, if the script runs while the firmware is running, it may erroneously interpret a normal printout as an ACK/NACK. However, this is unlikely because it can only ever happen if the ACK/NACK sequence gets encountered randomly during the `_wait_for_ack()` timeout window.

Tested with Zolertia RE-Mote (CC2538 + FT2232 (I think!)) and SmartRF06 + CC2650EM. Tested with 2.7.10 and 3.4.3.

Closes #13 