### PR TITLE
Auto-detect exact chip, flash size, disable bootloader byte offset in CCFG, chip package

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -875,8 +875,8 @@ if __name__ == "__main__":
             f = file(args[0], 'w').close() #delete previous file
             for i in range(0, length >> 2):
                 rdata = cmd.cmdMemRead(conf['address']+(i*4)) #reading 4 bytes at a time
-                mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address']+(i*4), ord(rdata[3]), ord(rdata[2]), ord(rdata[1]), ord(rdata[0])), '\r')
-                file(args[0], 'ab').write(''.join(reversed(rdata)))
+                mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address'] + (i * 4), rdata[3], rdata[2], rdata[1], rdata[0]), '\r')
+                file(args[0], 'ab').write(bytearray([rdata[n] for n in range(3, -1, -1)]))
             mdebug(5, "    Read done                                ")
 
         if conf['disable-bootloader']:

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -901,9 +901,9 @@ if __name__ == "__main__":
             mdebug(5, "Reading %s bytes starting at address 0x%x" % (length, conf['address']))
             with open(args[0], 'wb') as f:
                 for i in range(0, length >> 2):
-                    rdata = cmd.cmdMemRead(conf['address'] + (i * 4)) #reading 4 bytes at a time
-                    mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address'] + (i * 4), rdata[3], rdata[2], rdata[1], rdata[0]), '\r')
-                    f.write(bytearray([rdata[n] for n in range(3, -1, -1)]))
+                    rdata = device.read_memory(conf['address'] + (i * 4)) #reading 4 bytes at a time
+                    mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address'] + (i * 4), rdata[0], rdata[1], rdata[2], rdata[3]), '\r')
+                    f.write(rdata)
                 f.close()
             mdebug(5, "    Read done                                ")
 

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -866,10 +866,9 @@ if __name__ == "__main__":
 
         if conf['read']:
             length = conf['len']
-            if length < 4:  # reading 4 bytes at a time
-                length = 4
-            else:
-                length = length + (length % 4)
+
+            # Round up to a 4-byte boundary
+            length = (length + 3) & ~0x03
 
             mdebug(5, "Reading %s bytes starting at address 0x%x" % (length, conf['address']))
             with open(args[0], 'wb') as f:

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -873,7 +873,7 @@ if __name__ == "__main__":
 
             mdebug(5, "Reading %s bytes starting at address 0x%x" % (length, conf['address']))
             f = file(args[0], 'w').close() #delete previous file
-            for i in range(0,(length/4)):
+            for i in range(0, length >> 2):
                 rdata = cmd.cmdMemRead(conf['address']+(i*4)) #reading 4 bytes at a time
                 mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address']+(i*4), ord(rdata[3]), ord(rdata[2]), ord(rdata[1]), ord(rdata[0])), '\r')
                 file(args[0], 'ab').write(''.join(reversed(rdata)))

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -872,11 +872,12 @@ if __name__ == "__main__":
                 length = length + (length % 4)
 
             mdebug(5, "Reading %s bytes starting at address 0x%x" % (length, conf['address']))
-            f = file(args[0], 'w').close() #delete previous file
-            for i in range(0, length >> 2):
-                rdata = cmd.cmdMemRead(conf['address']+(i*4)) #reading 4 bytes at a time
-                mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address'] + (i * 4), rdata[3], rdata[2], rdata[1], rdata[0]), '\r')
-                file(args[0], 'ab').write(bytearray([rdata[n] for n in range(3, -1, -1)]))
+            with open(args[0], 'wb') as f:
+                for i in range(0, length >> 2):
+                    rdata = cmd.cmdMemRead(conf['address'] + (i * 4)) #reading 4 bytes at a time
+                    mdebug(5, " 0x%x: 0x%02x%02x%02x%02x" % (conf['address'] + (i * 4), rdata[3], rdata[2], rdata[1], rdata[0]), '\r')
+                    f.write(bytearray([rdata[n] for n in range(3, -1, -1)]))
+                f.close()
             mdebug(5, "    Read done                                ")
 
         if conf['disable-bootloader']:

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -585,6 +585,12 @@ class CC2538(Chip):
         mdebug(5, "Erasing %s bytes starting at address 0x%08X" % (self.size, self.flash_start_addr))
         return self.command_interface.cmdEraseMemory(self.flash_start_addr, self.size)
 
+    def read_memory(self, addr):
+        # CC2538's COMMAND_MEMORY_READ sends each 4-byte number in inverted
+        # byte order compared to what's written on the device
+        data = self.command_interface.cmdMemRead(addr)
+        return bytearray([data[x] for x in range(3, -1, -1)])
+
 class CC26xx(Chip):
     def __init__(self, command_interface):
         super(CC26xx, self).__init__(command_interface)
@@ -596,6 +602,11 @@ class CC26xx(Chip):
     def erase(self):
         mdebug(5, "Erasing all main bank flash sectors")
         return self.command_interface.cmdBankErase()
+
+    def read_memory(self, addr):
+        # CC26xx COMMAND_MEMORY_READ returns contents in the same order as
+        # they are stored on the device
+        return self.command_interface.cmdMemReadCC26xx(addr)
 
 def query_yes_no(question, default="yes"):
     valid = {"yes":True,   "y":True,  "ye":True,

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -311,7 +311,7 @@ class CommandInterface(object):
             version = self.receivePacket() # 4 byte answ, the 2 LSB hold chip ID
             if self.checkLastCmd():
                 assert len(version) == 4, "Unreasonable chip id: %s" % repr(version)
-                mdebug(5, "    Version 0x%02X%02X%02X%02X" % tuple(version))
+                mdebug(10, "    Version 0x%02X%02X%02X%02X" % tuple(version))
                 chip_id = (version[2] << 8) | version[3]
                 return chip_id
             else:
@@ -944,10 +944,10 @@ if __name__ == "__main__":
         chip_id_str = CHIP_ID_STRS.get(chip_id, None)
 
         if chip_id_str is None:
-            mdebug(0, 'Warning: unrecognized chip ID. Selecting CC13xx/CC26xx')
+            mdebug(10, '    Unrecognized chip ID. Trying CC13xx/CC26xx')
             device = CC26xx(cmd)
         else:
-            mdebug(5, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
+            mdebug(10, "    Target id 0x%x, %s" % (chip_id, chip_id_str))
             device = CC2538(cmd)
 
         # Choose a good default address unless the user specified -a

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -461,6 +461,23 @@ class CommandInterface(object):
             if self.checkLastCmd():
                 return data # self._decode_addr(ord(data[3]),ord(data[2]),ord(data[1]),ord(data[0]))
 
+    def cmdMemReadCC26xx(self, addr):
+        cmd = 0x2A
+        lng = 9
+
+        self._write(lng) # send length
+        self._write(self._calc_checks(cmd, addr, 2)) # send checksum
+        self._write(cmd) # send cmd
+        self._write(self._encode_addr(addr)) # send addr
+        self._write(1) # send width, 4 bytes
+        self._write(1) # send number of reads
+
+        mdebug(10, "*** Mem Read (0x2A)")
+        if self._wait_for_ack("Mem Read (0x2A)", 1):
+            data = self.receivePacket()
+            if self.checkLastCmd():
+                return data
+
     def cmdMemWrite(self, addr, data, width): # untested
         # TODO: check width for 1 or 4 and data size
         cmd=0x2B

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -235,7 +235,7 @@ class CommandInterface(object):
 
         size = got[0] #rcv size
         chks = got[1] #rcv checksum
-        data = self._read(size-2) # rcv data
+        data = bytearray(self._read(size - 2)) # rcv data
 
         mdebug(10, "*** received %x bytes" % size)
         if chks == sum(data)&0xFF:

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -761,6 +761,10 @@ if __name__ == "__main__":
         if conf['read'] and not conf['write'] and conf['verify']:
             raise Exception('Verify after read not implemented.')
 
+        if conf['len'] < 0:
+            raise Exception('Length must be positive but %d was provided'
+                            % (conf['len'],))
+
         # Try and find the port automatically
         if conf['port'] == 'auto':
             ports = []


### PR DESCRIPTION
This pull adds the following:

* Auto-detection of flash size for all supported devices
* Auto-detection of the exact address of the "bootloader disable" byte (changes with flash size)
* Printing of primary IEEE address
* Printing of some other chip info, such as exact member of the CC13xx/CC26xx family, package type, PG versions etc.

The intention is to support all devices, so:
* CC2538: 16/32KB RAM, 128/256/512 flash should all be supported
* CC2630, CC2640, CC2650 should all be supported
* CC1310: F32, F64, F128 should all be supported
* CC1350 should also be supported whenever it gets released

Requires #39 

Closes #5 

This is what it looks like on CC2538 (SmartRF + CC2538EM):
<pre>
$ python cc2538-bsl.py -w -e -v -p /dev/tty.usbserial-00002014B test-firmwares/cc2538.bin 
Opening port /dev/tty.usbserial-00002014B, baud 500000
Reading data from test-firmwares/cc2538.bin
Connecting to target...
<b>CC2538 PG2.0: 512KB Flash, 16KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:AE:26:07:01</b>
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x3905ac1c)
</pre>

CC2650:

<pre>
$ python cc2538-bsl.py -w -e -v -p /dev/tty.usbserial-00002014B test-firmwares/cc2650.bin 
Opening port /dev/tty.usbserial-00002014B, baud 500000
Reading data from test-firmwares/cc2650.bin
Connecting to target...
<b>CC2650 PG2.2 (7x7mm): 128KB Flash, 20KB SRAM, CCFG.BL_CONFIG at 0x0001FFD8
Primary IEEE Address: 00:12:4B:00:06:8B:51:82</b>
Erasing all main bank flash sectors
    Erase done
Writing 131072 bytes starting at address 0x00000000
Write 128 bytes at 0x0001FF800
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x3c56d896)
</pre>
