### PR TITLE
Fix CC2538 RAM size calculation

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -675,7 +675,7 @@ class CC2538(Chip):
         self.size = (model[3] & 0x70) * 0x2000 # in bytes
         self.bootloader_address = self.flash_start_addr + self.size - ccfg_len
 
-        sram = 16 + (((model[2] << 8) | model[3]) & 0x380) >> 5 # in KB
+        sram = 16 + ((((model[2] << 8) | model[3]) & 0x380) >> 5) # in KB
 
         pg = self.command_interface.cmdMemRead(FLASH_CTRL_DIECFG2)
         pg_major = (pg[2] & 0xF0) >> 4


### PR DESCRIPTION
Due to bad usage of parentheses, CC2538 RAM size is incorrectly detected as 16KB on 32KB chips.

Sorry about that - back to the basics :S