### PR TITLE
Increase connect timeout to 0.1 seconds

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -236,7 +236,7 @@ class CommandInterface(object):
         # it has actually entered its bootloader mode.
         #
         # See contiki-os/contiki#1533
-        time.sleep(0.002)
+        time.sleep(0.1)
 
     def close(self):
         self.sp.close()


### PR DESCRIPTION
As per #52, increase the connect timeout from 0.002 to 0.1 seconds.
This appears to allow enough time for the BSL to start irrespective of
the platform.