### PR TITLE
Fix CC2538 information

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -699,6 +699,8 @@ class CC2538(Chip):
 
         pg = self.command_interface.cmdMemRead(FLASH_CTRL_DIECFG2)
         pg_major = (pg[2] & 0xF0) >> 4
+        if pg_major == 0:
+            pg_major = 1
         pg_minor = pg[2] & 0x0F
 
         ieee_addr = self.command_interface.cmdMemRead(addr_ieee_address_primary + 4)

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -708,8 +708,13 @@ class CC2538(Chip):
             pg_major = 1
         pg_minor = pg[2] & 0x0F
 
-        ieee_addr = self.command_interface.cmdMemRead(addr_ieee_address_primary + 4)
-        ieee_addr += self.command_interface.cmdMemRead(addr_ieee_address_primary)
+        ti_oui = bytearray([0x00, 0x12, 0x4B])
+        ieee_addr = self.command_interface.cmdMemRead(addr_ieee_address_primary)
+        ieee_addr_end = self.command_interface.cmdMemRead(addr_ieee_address_primary + 4)
+        if ieee_addr[:3] == ti_oui:
+            ieee_addr += ieee_addr_end
+        else:
+            ieee_addr = ieee_addr_end + ieee_addr
 
         mdebug(5, "CC2538 PG%d.%d: %dKB Flash, %dKB SRAM, CCFG at 0x%08X"
                % (pg_major, pg_minor, self.size >> 10, sram,

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -699,7 +699,8 @@ class CC2538(Chip):
             self.size = 0x10000 # in bytes
         self.bootloader_address = self.flash_start_addr + self.size - ccfg_len
 
-        sram = 16 + ((((model[2] << 8) | model[3]) & 0x380) >> 5) # in KB
+        sram = (((model[2] << 8) | model[3]) & 0x380) >> 7
+        sram = (2 - sram) << 3 if sram <= 1 else 32 # in KB
 
         pg = self.command_interface.cmdMemRead(FLASH_CTRL_DIECFG2)
         pg_major = (pg[2] & 0xF0) >> 4

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -692,7 +692,11 @@ class CC2538(Chip):
 
         #Read out primary IEEE address, flash and RAM size
         model = self.command_interface.cmdMemRead(FLASH_CTRL_DIECFG0)
-        self.size = (model[3] & 0x70) * 0x2000 # in bytes
+        self.size = (model[3] & 0x70) >> 4
+        if 0 < self.size <= 4:
+            self.size *= 0x20000 # in bytes
+        else:
+            self.size = 0x10000 # in bytes
         self.bootloader_address = self.flash_start_addr + self.size - ccfg_len
 
         sram = 16 + ((((model[2] << 8) | model[3]) & 0x380) >> 5) # in KB


### PR DESCRIPTION
Fix possible wrong die revision, flash memory size, SRAM size, or primary IEEE address.

I have several parts for which `cc2538-bsl` reported a wrong primary IEEE address. Regarding the die revision, the very early parts must have been affected by the issue fixed here. As to the flash memory and SRAM sizes, the cases fixed here do not seem to exist in officially released devices, but they did not match TI's ROM and code, so fix this too in order to avoid any possible current or future issue.