### PR TITLE
cc2538-bsl.py: add new id to CHIP_ID_STRS

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -91,7 +91,9 @@ def mdebug(level, message, attr='\n'):
         print(message, end=attr, file=sys.stderr)
 
 # Takes chip IDs (obtained via Get ID command) to human-readable names
-CHIP_ID_STRS = {0xb964: 'CC2538'}
+CHIP_ID_STRS = {0xb964: 'CC2538',
+                0xb965: 'CC2538'
+                }
 
 RETURN_CMD_STRS =  {0x40: 'Success',
                     0x41: 'Unknown command',


### PR DESCRIPTION
After switching from old v1 to version 2.1 the tool didn't work with two *SmartRF06EB/CC2538EM* kits here anymore. Luckily, with the help of "-V", I found out the my two *CC2538EM* are returning a different chip as expected.
This PR adds the reported id to the dictionary.

After the fix this gorgeous tool works again.