### PR TITLE
Added 'ttyACM' to list of USB-like names

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -1027,7 +1027,7 @@ if __name__ == "__main__":
             ports = []
 
             # Get a list of all USB-like names in /dev
-            for name in ['tty.usbserial', 'ttyUSB', 'tty.usbmodem', 'tty.SLAB_USBtoUART']:
+            for name in ['ttyACM', 'tty.usbserial', 'ttyUSB', 'tty.usbmodem', 'tty.SLAB_USBtoUART']:
                 ports.extend(glob.glob('/dev/%s*' % name))
 
             ports = sorted(ports)


### PR DESCRIPTION
CC1310 launchpad shows as ttyACM0 and ttyACM1 when connected via USB. This is on ubuntu 14.04, which is part of the VM bundle that is Instant Contiki.