### PR TITLE
Support for newer CC26xx, CC2640R2 in particular.

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -812,7 +812,7 @@ class CC26xx(Chip):
             pg_str = "PG2.0"
         elif pg == 7:
             pg_str = "PG2.1"
-        elif pg == 8:
+        elif pg == 8 or pg == 11:
             rev_minor = self.command_interface.cmdMemReadCC26xx(CC26xx.MISC_CONF_1)[0]
             if rev_minor == 0xFF:
                 rev_minor = 0x00


### PR DESCRIPTION
In the latest versions of CC2640 (at least CC2640R2) pg revision number returned has changed to 11 (0x0b). See  "CC13x0, CC26x0 SimpleLinkTM Wireless MCU Technical Reference Manual" (swcu117h.pdf) page 879.
I used "...or pg == 11" instead of setting "pg >= 8" since I have no idea what the versions 9 and 10 are up to.