### PR TITLE
Don't fall over if the incorrect python-magic gets imported

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -52,8 +52,9 @@ import traceback
 
 try:
     import magic
+    magic.from_file
     have_magic = True
-except ImportError:
+except (ImportError, AttributeError):
     have_magic = False
 
 try:


### PR DESCRIPTION
Fantastically, there are two modules called `python-magic`, both used by importing `magic`, but the two of them have very very incompatible APIs.

The one we are using (and hosted on pypi) is this this one: https://github.com/ahupp/python-magic

The other one ships with libmagic. Some linux installations come with the "wrong" python magic installed. In these python installations, we will encounter this error:

```
Opening port /dev/ttyACM0, baud 500000
Reading data from my_first_app.hex
ERROR: 'module' object has no attribute 'from_file'
```

This pull fixes our behaviour in those installations. python-magic is not critical for the correct operation of this script, so what we do is check (at the time of importing) whether `magic` has an attribute called `from_file`. If it does then we actually imported the correct package so we use it. If it does not, we proceed as normal without magic support.

Reported by @RoyalBN on the [contiki-ng/contiki-ng](https://github.com/contiki-ng/contiki-ng) gitter

