### PR TITLE
Updated help text when pyserial is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To communicate with the uart port of the SoC you need a usb to serial converter:
 
 ### Dependencies
 
+This script uses the pyserial package to communicate with the serial port and chip (https://pypi.org/project/pyserial/). You can install it by running `pip install pyserial`.
+
 If you want to be able to program your device from an Intel Hex file, you will need to install the IntelHex package: https://pypi.python.org/pypi/IntelHex (e.g. by running `pip install intelhex`).
 
 The script will try to auto-detect whether your firmware is a raw binary or an Intel Hex by using python-magic:

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -75,14 +75,12 @@ try:
     import serial
 except ImportError:
     print('{} requires the Python serial library'.format(sys.argv[0]))
-    print('Please install it with one of the following:')
+    print('Please install it with:')
     print('')
     if PY3:
-        print('   Ubuntu:  sudo apt-get install python3-serial')
-        print('   Mac:     sudo port install py34-serial')
+        print('   pip3 install pyserial')
     else:
-        print('   Ubuntu:  sudo apt-get install python-serial')
-        print('   Mac:     sudo port install py-serial')
+        print('   pip2 install pyserial')
     sys.exit(1)
 
 


### PR DESCRIPTION
Small change on help text when pyserial is missing. pip seems like a better option than macports. Not sure if `pip2` and `pip3` distinction is only made when installing with brew though.