### PR TITLE
made --version option python3 compatible

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -63,7 +63,7 @@ except ImportError:
     have_hex_support = False
 
 # version
-VERSION_STRING = "2.1"
+__version__ = "2.1"
 
 # Verbose level
 QUIET = 5
@@ -978,10 +978,10 @@ def print_version():
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]
-        version = line.strip()
+        version = line.decode('utf-8').strip()
     except:
         # We're not in a git repo, or git failed, use fixed version string.
-        version = VERSION_STRING
+        version = __version__
     print('%s %s' % (sys.argv[0], version))
 
 


### PR DESCRIPTION
The `--version` option didn't look that good in python3, this fixes it. Also changed to `__version__` naming for the version string.

The whole _get the version string from git_ isn't working as well as I intended it to since for example [RIOT](https://github.com/RIOT-OS/RIOT) is just copying the script into their source instead of using submodules (I tried convincing them). So `--version` just gives the version of their main git repo instead of the actual version of this script.
Any ideas to improve the version string, except for just hard-coding it.