### PR TITLE
Fix SyntaxWarning when running with Python 3.8+

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -177,7 +177,7 @@ class FirmwareFile(object):
             The firmware's CRC32, ready for comparison with the CRC
             returned by the ROM bootloader's COMMAND_CRC32
         """
-        if self._crc32 is None:
+        if self._crc32 == None:
             self._crc32 = binascii.crc32(bytearray(self.bytes)) & 0xffffffff
 
         return self._crc32
@@ -382,7 +382,7 @@ class CommandInterface(object):
             return 1
         else:
             stat_str = RETURN_CMD_STRS.get(stat[0], None)
-            if stat_str is None:
+            if stat_str == None:
                 mdebug(0, "Warning: unrecognized status returned "
                           "0x%x" % stat[0])
             else:
@@ -920,7 +920,7 @@ def query_yes_no(question, default="yes"):
              "ye": True,
              "no": False,
              "n": False}
-    if default is None:
+    if default == None:
         prompt = " [y/n] "
     elif default == "yes":
         prompt = " [Y/n] "
@@ -932,7 +932,7 @@ def query_yes_no(question, default="yes"):
     while True:
         sys.stdout.write(question + prompt)
         choice = input().lower()
-        if default is not None and choice == '':
+        if default != None and choice == '':
             return valid[default]
         elif choice in valid:
             return valid[choice]
@@ -1200,7 +1200,7 @@ if __name__ == "__main__":
         chip_id = cmd.cmdGetChipId()
         chip_id_str = CHIP_ID_STRS.get(chip_id, None)
 
-        if chip_id_str is None:
+        if chip_id_str == None:
             mdebug(10, '    Unrecognized chip ID. Trying CC13xx/CC26xx')
             device = CC26xx(cmd)
         else:
@@ -1208,7 +1208,7 @@ if __name__ == "__main__":
             device = CC2538(cmd)
 
         # Choose a good default address unless the user specified -a
-        if conf['address'] is None:
+        if conf['address'] == None:
             conf['address'] = device.flash_start_addr
 
         if conf['force_speed'] != 1 and device.has_cmd_set_xosc:


### PR DESCRIPTION
Python 3.8+ will emit a SyntaxWarning when `is` or `is not` is used. This PR replaces them accordingly. 

Log when `is`/`is not` is used:

```
➜ python3 cc2538-bsl.py -p /dev/tty.usbserial-1420 -evw ~/Desktop/znp_CC26X2R1_LAUNCHXL_tirtos_ccs.hex
/Users/Koenkk/Git/cc2538-bsl/cc2538-bsl.py:971: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if int(value) % int(device.page_size) is not 0:
/Users/Koenkk/Git/cc2538-bsl/cc2538-bsl.py:976: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if int(value, 16) % int(device.page_size) is not 0:
Opening port /dev/tty.usbserial-1420, baud 500000
Reading data from /Users/Koenkk/Desktop/znp_CC26X2R1_LAUNCHXL_tirtos_ccs.hex
Your firmware looks like an Intel Hex file
Connecting to target...
```

Ref: https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/  and https://bugs.python.org/issue34850