### PR TITLE
add write_timeout to serial port

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -199,9 +199,9 @@ class CommandInterface(object):
         # this stage: We need to set its attributes up depending on what object
         # we get.
         try:
-            self.sp = serial.serial_for_url(aport, do_not_open=True, timeout=10)
+            self.sp = serial.serial_for_url(aport, do_not_open=True, timeout=10, write_timeout=10)
         except AttributeError:
-            self.sp = serial.Serial(port=None, timeout=10)
+            self.sp = serial.Serial(port=None, timeout=10, write_timeout=10)
             self.sp.port = aport
 
         if ((os.name == 'nt' and isinstance(self.sp, serial.serialwin32.Serial)) or \


### PR DESCRIPTION
### What
Disallow the script to hang forever if the serial fails to write.

How to reproduce: Try to flash a device without connecting it to the serial port.
- Before this PR: Script will hang forever.
- After this PR: Script will hang for 10 seconds.

### Why
The serial port contains a `timeout` attribute on construction.
During a test, I noticed the script stuck as if ignoring the `timeout`.
Discovered that `timeout` is for reading, but there is a `write_timeout` attribute as well, which is required not to hang if the device does not _acks_ the write.
Source 1: [PySerial docs](https://pyserial.readthedocs.io/en/latest/pyserial_api.html)
Source 2: [Related Stack Overflow question](https://stackoverflow.com/questions/39032581/python-serial-write-timeout)

### How
Added `write_timeout` attribute to serial port construction using same value as for `timeout`.

### What the reviewer should focus on
Is this aligned with the script intentions? (to actually timeout on write error)