### PR TITLE
Update README.md documenting bootloader-sonoff-usb

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ The script has been tested with SmartRF06EB + CC2650 EM. The physical wiring on 
 For sensortags CC1350STK:
 It is possible to solder cables to R21 and R22 for flashing using the Serial Bootloader. This [issue] has instructions about flashing the CC1350STK sensortag.
 
-For the CC13xx and CC26xx families, the ROM bootloader is configured through the `BL_CONFIG` 'register' in CCFG. `BOOTLOADER_ENABLE` should be set to `0xC5` to enable the bootloader in the first place.
+For ITead SONOFF Zigbee 3.0 USB Dongle Plus:
+For the CC2652P based "SONOFF Zigbee 3.0 USB Dongle Plus" (model "ZBDongle-P") adapter from ITead you need to invoke toggle to activate bootloader with `--bootloader-sonoff-usb` if you do not want to open its enclosure to manually start the bootloader with the boot button on the PCB.
+
+For all the CC13xx and CC26xx families, the ROM bootloader is configured through the `BL_CONFIG` 'register' in CCFG. `BOOTLOADER_ENABLE` should be set to `0xC5` to enable the bootloader in the first place.
 
 This is enough if the chip has not been programmed with a valid image. If a valid image is present, then the remaining fields of `BL_CONFIG` and the `ERASE_CONF` register must also be configured correctly:
 


### PR DESCRIPTION
Update README.md documenting new `--bootloader-sonoff-usb` option from https://github.com/JelmerT/cc2538-bsl/pull/114

Note that @JelmerT mentioned in https://github.com/JelmerT/cc2538-bsl/pull/114 that option might be renamed to `--bootloader-imply-gate` in the future, see comment:

> This PR adds support for the Itead Sonoff CC2652P usb dongle (https://itead.cc/product/sonoff-zigbee-3-0-usb-dongle-plus/) with the new option `--bootloader-sonoff-usb`. With this new option you don't have to manually start the bootloader with the 2 buttons on the PCB anymore.
> 
> This dongle does not have a 1 to 1 connection between RTS DTR and RST IO15, but uses 2 NPN transistors to connect them together with the following truth table:
> 
> ```
> DTR  RTS  |  RST  IO15
> 1     1   |   1    1
> 0     0   |   1    1
> 1     0   |   0    1
> 0     1   |   1    0
> ```
> 
> I'm not aware of any other HW that uses this connection, so I'm naming the option after the specific hardware. In the future this should probably get a more general name like `--bootloader-imply-gate` or something. (the truth table is an imply and nimply port)
> 
> If you have this specific HW, please test and report here.

