### PR TITLE
Add link to Docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It can be used to erase, program, verify and read the flash of those SoCs with a
 
 To run this script you need a Python interpreter, Linux and Mac users should be fine, Windows users have a look here: [Python Download][python].
 
+Alternatively, Docker can be used to run this script as a one-liner without the need to install dependencies, see [git-developer/ti-cc-tool](https://github.com/git-developer/ti-cc-tool) for details.
+
 To communicate with the uart port of the SoC you need a usb to serial converter:
 * If you use the SmartRF06 board with an Evaluation Module (EM) mounted on it you can use the on-board ftdi chip. Make sure the "Enable UART" jumper is set on the board. You can have a look [here][contiki cc2538dk] for more info on drivers for this chip on different operating systems.
 * If you use a different platform, there are many cheap USB to UART converters available, but make sure you use one with 3.3v voltage levels.


### PR DESCRIPTION
This is a request to adding a link to the Docker documentation (see https://github.com/JelmerT/cc2538-bsl/issues/120).