### PR TITLE
Clean up unnecessary install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "version_scheme": "post-release",
         "local_scheme": "node-and-date",
         },
-    install_requires=["pip>=10", "setuptools", "wheel", "pyserial"],
+    install_requires=["pyserial"],
     extras_require={
         '': ["intelhex"],
         'intelhex': ["python-magic"]


### PR DESCRIPTION
`pip`, `setuptools`, and `wheel` are not depended upon by the source code.