### PR TITLE
Fix extras_require specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         },
     install_requires=["pyserial"],
     extras_require={
-        '': ["intelhex"],
         'intelhex': ["python-magic"]
     },
     scripts=["cc2538-bsl.py"],


### PR DESCRIPTION
Otherwise setuptools will now error out with

> setuptools.extern.packaging.markers.InvalidMarker: Expected a marker variable or quoted string