### PR TITLE
Add flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ To run this script you need a Python interpreter, Linux and Mac users should be 
 
 Alternatively, Docker can be used to run this script as a one-liner without the need to install dependencies, see [git-developer/ti-cc-tool](https://github.com/git-developer/ti-cc-tool) for details.
 
+Or if you [install Nix](https://github.com/DeterminateSystems/nix-installer) you can run it like this e.g.:
+
+```
+$ nix run github:JelmerT/cc2538-bsl -- --help
+```
+
 To communicate with the uart port of the SoC you need a usb to serial converter:
 * If you use the SmartRF06 board with an Evaluation Module (EM) mounted on it you can use the on-board ftdi chip. Make sure the "Enable UART" jumper is set on the board. You can have a look [here][contiki cc2538dk] for more info on drivers for this chip on different operating systems.
 * If you use a different platform, there are many cheap USB to UART converters available, but make sure you use one with 3.3v voltage levels.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705677747,
+        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Script to upload firmware via the serial boot loader onto the CC13xx, CC2538 and CC26xx SoC.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      debug = true;
+      imports = [];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      perSystem = { self', config, pkgs, system, ... }: {
+        packages.default =
+          let
+            python = pkgs.python3.withPackages (p: [
+              p.intelhex
+              p.pyserial
+              p.python-magic
+            ]);
+            cc2538-bsl_py = builtins.path {
+              name = "cc2538-bsl.py";
+              path = ./cc2538-bsl.py;
+            };
+          in
+          pkgs.writeShellScriptBin "cc2538-bsl.sh" ''
+            ${python}/bin/python3 ${cc2538-bsl_py} "$@"
+          '';
+      };
+    };
+}


### PR DESCRIPTION
Thanks for this script, I've been using it for quite some time!

This PR packages the script and its dependencies with [Nix](https://en.wikipedia.org/wiki/Nix_(package_manager))

Some advantages of this over Docker:
- No additional build step, just go `nix run ...` and it will download things and run
- No issues with permissions. It just runs as the current user.
- Always up to date (unless there's an upgrade in a dependency, then this might need reviewing)
- People can pin a specific commit e.g. `nix run github:JelmerT/cc2538-bsl/208cf7a79c6443d3f1c218d8fee1d18096165664` (of course this only works from the moment this file is in the repo)