### PR TITLE
fix: check force_speed by absence of property

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -1147,7 +1147,7 @@ if __name__ == "__main__":
         if not args.address:
             args.address = device.flash_start_addr
 
-        if args.force_speed != 1 and device.has_cmd_set_xosc:
+        if not args.force_speed and device.has_cmd_set_xosc:
             if cmd.cmdSetXOsc():  # switch to external clock source
                 cmd.close()
                 args.baud = 1000000


### PR DESCRIPTION
Fix for https://github.com/JelmerT/cc2538-bsl/issues/162