### PR TITLE
Add a GitHub Action for a container image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+.travis.yml
+Dockerfile

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -12,8 +12,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
-  #REGISTRY_IMAGE: ghcr.io/jelmert/cc2538-bsl
+  REGISTRY_IMAGE: ghcr.io/jelmert/cc2538-bsl
 
 # permissions are needed if pushing to ghcr.io
 permissions:

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -53,7 +53,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
-        name: Login to GitHub Container Registry
+        name: Login to Image Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -105,7 +105,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
       -
-        name: Login to Docker Hub
+        name: Login to Image registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,124 @@
+name: image build
+
+on:
+  push:
+    branches:
+      - "master"
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.md'
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+  #REGISTRY_IMAGE: ghcr.io/jelmert/cc2538-bsl
+
+# permissions are needed if pushing to ghcr.io
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          - linux/i386
+    steps:
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: matrix.platform != 'linux/amd64'
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3-alpine
+ARG REPO_URL='.[cc2538-bsl,intelhex]'
+ADD . /tmp/build/
+RUN cd /tmp/build && \
+    apk add --no-cache file git && \
+    export PIP_ROOT_USER_ACTION=ignore && \
+    pip3 install "${REPO_URL}" && \
+    pip3 uninstall -y setuptools wheel pip && \
+    apk del --no-cache -r git && \
+    rm -r /root/.cache /tmp/build
+RUN adduser -D user && addgroup user dialout
+USER user
+ADD run /usr/local/bin/
+WORKDIR /tmp
+ENTRYPOINT ["run"]

--- a/run
+++ b/run
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+[ -z "${TRACE-}" ] || set -x
+
+log() {
+  echo >&2 "${@}"
+}
+
+error() {
+  log "ERROR: ${@}"
+  return 1
+}
+
+prepare_firmware() {
+  set -eu
+  file="${1}"
+  if [ ! -r "${file}" ]; then
+    error "Unreadable firmware file '${file}'"
+  elif file -b "${file}" | grep -qi ^zip; then
+    unzip "${file}" | sed -nE 's/  inflating: (.+)/\1/p'
+  else
+    echo "${file}"
+  fi
+}
+
+run() {
+  local source="${1}" file
+  shift
+  if [ -n "${source}" ]; then
+    file="$(prepare_firmware "${source}")"
+    [ "${file}" = "${source}" ] || log "Firmware source: '${source}'"
+    if [ -z "${file}" ]; then
+      error "Firmware source does not contain a firmware file."
+    elif [ "$(echo "${file}" | wc -l)" -gt 1 ]; then
+      error "Expected exactly 1 firmware file, but found: $(echo "${file}" | xargs)"
+    else
+      log "Firmware file:   '${file}'"
+      set -- "${@}" "${file}"
+    fi
+  fi
+  cc2538-bsl.py "${@}"
+}
+
+main() {
+  local source
+  if [ -n "${FIRMWARE_FILE-}" ]; then
+    source="${FIRMWARE_FILE}"
+  elif [ -n "${FIRMWARE_URL-}" ]; then
+    log "Downloading firmware from ${FIRMWARE_URL}"
+    source="$(wget "${FIRMWARE_URL}" 2>&1 | sed -nE "s/^'(.+)' saved$/\1/p")"
+    [ -n "${source}" ] || error "Download of firmware was not successful."
+  else
+    log "WARNING: neither FIRMWARE_URL nor FIRMWARE_FILE is set as environment variable."
+  fi
+  run "${source-}" "${@}"
+}
+
+main "${@}"


### PR DESCRIPTION
This PR adds a GitHub Action for a container image build.

Currently, the container image is provided in a separate project [git-developer/ti-cc-tool](https://github.com/git-developer/ti-cc-tool). I'd like to contribute it to this project.

The building blocks are:
1. A `Dockerfile` that contains the build instructions. By default, sources are taken from the local filesystem and all extra features are included. This can be configured by setting the build-arg `REPO_URL` (e.g. to an URL).
2. A `run` shell script that allows firmware files as URL or local file, in native (bin/hex) and zipped format. It is used as entrypoint for the container image.
3. A GitHub Action workflow `.github/workflows/image-build.yml` that starts the image build. It is currently configured to trigger a build on creation of a release (via the GitHub Web-UI) and additionally on pushes to `master`. The image is created for several platforms in parallel (e.g. `amd64`and `arm/v7`) and uploaded to the GitHub package registry of this project.

I created a release called _demo-1_ in my fork for you to get an impression what happens and how it looks like:
* [Actions](https://github.com/git-developer/cc2538-bsl/actions)
* [Releases](https://github.com/git-developer/cc2538-bsl/releases)
* [Packages](https://github.com/git-developer/cc2538-bsl/pkgs/container/cc2538-bsl)

This PR probably needs some discussions and finetuning. Please add your comments so that we can elaborate on how it can be adapted to your requirements.

User documentation is not part of this PR yet. I suggest to merge the README of [git-developer/ti-cc-tool](https://github.com/git-developer/ti-cc-tool) with this project.