### PR TITLE
Fix SONOFF chip reset after flashing

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -241,6 +241,10 @@ class CommandInterface(object):
 
             set_bootloader_pin(1)
             set_reset_pin(0)
+
+            # wait to enter bootloader, then deassert bootloader pin
+            time.sleep(0.002)
+            set_reset_pin(1)
         else:
             set_bootloader_pin(1 if not dtr_active_high else 0)
             set_reset_pin(0)


### PR DESCRIPTION
The chip will return to the bootloader after cmdReset if the bootloader pin is not de-asserted after entering the bootloader. To fix this, this patch de-asserts the bootloader pin after a delay.