### PR TITLE
ieee_address fix

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -1221,7 +1221,7 @@ if __name__ == "__main__":
                 raise Exception("NO CRC32 match: Local = 0x%x, "
                                 "Target = 0x%x" % (crc_local, crc_target))
 
-        if args.ieee_address != 0 and args.ieee_address != None:
+        if args.ieee_address is not None:
             ieee_addr = parse_ieee_address(args.ieee_address)
             mdebug(5, "Setting IEEE address to %s"
                        % (':'.join(['%02x' % b

--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -1221,7 +1221,7 @@ if __name__ == "__main__":
                 raise Exception("NO CRC32 match: Local = 0x%x, "
                                 "Target = 0x%x" % (crc_local, crc_target))
 
-        if args.ieee_address != 0:
+        if args.ieee_address != 0 and args.ieee_address != None:
             ieee_addr = parse_ieee_address(args.ieee_address)
             mdebug(5, "Setting IEEE address to %s"
                        % (':'.join(['%02x' % b


### PR DESCRIPTION
# Error fix  `ERROR: int() can't convert non-string with explicit base`

## Command:
`python3 cc2538-bsl.py -p COM7 -evw --bootloader-sonoff-usb CC1352P2_CC2652P_launchpad_coordinator_20230507.hex`
## Hex reference:
`https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_coordinator_20230507.zip`


## Log:
```
sonoff
Opening port COM7, baud 500000
Reading data from CC1352P2_CC2652P_launchpad_coordinator_20230507.hex
Your firmware looks like an Intel Hex file
Connecting to target...
CC1350 PG2.0 (7x7mm): 352KB Flash, 20KB SRAM, CCFG.BL_CONFIG at 0x00057FD8
Primary IEEE Address: 00:12:4B:00:2C:40:10:06
    Performing mass erase
Erasing all main bank flash sectors
    Erase done
Writing 360448 bytes starting at address 0x00000000
Write 104 bytes at 0x00057F988
    Write done
Verifying by comparing CRC32 calculations.
    Verified (match: 0xe83aa727)
ERROR: int() can't convert non-string with explicit base
```

# Problem fix:

Change at line `1224` : added `and args.ieee_address != None` to if statement.

```
if args.ieee_address != 0  and args.ieee_address != None:
            ieee_addr = parse_ieee_address(args.ieee_address)
            mdebug(5, "Setting IEEE address to %s"
                       % (':'.join(['%02x' % b
                                    for b in struct.pack('>Q', ieee_addr)])))
            ieee_addr_bytes = struct.pack('<Q', ieee_addr)

            if cmd.writeMemory(device.addr_ieee_address_secondary,
                               ieee_addr_bytes):
                mdebug(5, "    "
                          "Set address done")
            else:
                raise CmdException("Set address failed")
```