### PR TITLE
fix: improve compatibility with newer file magic detection

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -125,7 +125,7 @@ class FirmwareFile(object):
             from magic import from_file
             file_type = from_file(path, mime=True)
 
-            if file_type == 'text/plain':
+            if file_type == 'text/plain' or file_type == 'text/x-hex':
                 mdebug(5, "Firmware file: Intel Hex")
                 self.__read_hex(path)
             elif file_type == 'application/octet-stream':


### PR DESCRIPTION
newer versions of magic from file_open now detect the hex file as `text/x-hex` instead of `text/plain`