### PR TITLE
file can return `text/x-hex` for the intel hex file

### DIFF
--- a/cc2538-bsl.py
+++ b/cc2538-bsl.py
@@ -125,7 +125,7 @@ class FirmwareFile(object):
             from magic import from_file
             file_type = from_file(path, mime=True)
 
-            if file_type == 'text/plain':
+            if file_type == 'text/plain' or file_type == 'text/x-hex':
                 mdebug(5, "Firmware file: Intel Hex")
                 self.__read_hex(path)
             elif file_type == 'application/octet-stream':


### PR DESCRIPTION
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/5555b9a5-29f9-402d-9d84-66b3ed50cd16" />

Flashed Sonoff usb dongle. No issues so far