### PR TITLE
fix: global variable 'QUIET' UnboundLocalError in main_cli exception handler

### DIFF
--- a/cc2538_bsl/cc2538_bsl.py
+++ b/cc2538_bsl/cc2538_bsl.py
@@ -1089,6 +1089,8 @@ def cli_setup():
     return parser.parse_args()
 
 def main_cli():
+    global QUIET
+    
     args = cli_setup()
 
     force_speed = False


### PR DESCRIPTION
### Description
Fixes an `UnboundLocalError: cannot access local variable 'QUIET' where it is not associated with a value` inside the `except` block of `main_cli()`.

### Cause
Because `QUIET` is assigned within `main_cli()` (under `if args.V:` or `if args.q:`), Python treats it as a local variable. If neither `-V` nor `-q` is passed in the command line, the local `QUIET` variable remains uninitialized when an exception occurs, masking the original hardware/communication exception.

This fixes the crash and allows the script to properly output the actual error (e.g., `CmdException: Timeout waiting for ACK/NACK`).

### Notes
This secondary crash was also observed and reported by users in issue https://github.com/JelmerT/cc2538-bsl/issues/186 (e.g., during serial connection timeouts).